### PR TITLE
Created a configuration file for the Youtube API key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,5 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-
-
+# Configuration Files
+config/local*.json

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,5 @@
+{
+  "Youtube": {
+    "apiKey": "defaultApiKey"
+  }
+}

--- a/external/youtube_api.js
+++ b/external/youtube_api.js
@@ -1,54 +1,55 @@
 var request = require("request");
-var NodeCache = require( "node-cache" );
-var youtubeCache = new NodeCache({ stdTTL: 300, checkperiod: 120 });
+var config = require('config');
+var NodeCache = require("node-cache");
+var youtubeCache = new NodeCache({stdTTL: 300, checkperiod: 120});
 
 //todo Keys should not be hardcoded
-var apikey = "AIzaSyD6KohaRaKeIFg24tYKx4YUa7rxt156duE";
+var apikey = config.get("Youtube.apiKey");
 var channelid = "UCYq97D1iaRz5fL1c515MX-g";
 
 var requestString = "https://www.googleapis.com/youtube/v3/search?key=" + apikey +
     "&channelId=" + channelid + "&part=snippet,id&order=date&maxResults=5";
 
 self = module.exports = {
-    getVideos: function(callback){
+    getVideos: function (callback) {
         //var cacheKey = "molloy-youtube";
         //var cached = youtubeCache.get(cacheKey);
         //if(cacheKey in cached) {
         //    var result = cached[cacheKey];
-         //   callback(null, result);
+        //   callback(null, result);
         //} else {
-            console.log(requestString);
-            request(requestString,function(error,response,body){
-                body = JSON.parse(body);
-                if(!error) {
-                    //youtubeCache.set(cacheKey, body);
-                    callback(null, body);
-                } else {
-                    callback(error);
-                }
+        console.log(requestString);
+        request(requestString, function (error, response, body) {
+            body = JSON.parse(body);
+            if (!error) {
+                //youtubeCache.set(cacheKey, body);
+                callback(null, body);
+            } else {
+                callback(error);
+            }
 
-            });
+        });
         //}
 
     },
-    getVideoPage: function(callback,pageToken){
+    getVideoPage: function (callback, pageToken) {
         //var cacheKey = "molloy-youtube";
         //var cached = youtubeCache.get(cacheKey);
         //if(cacheKey in cached) {
         //    var result = cached[cacheKey];
         //    callback(null, result);
         //} else {
-            console.log(requestString + "&pageToken=" + pageToken);
-            request(requestString + "&pageToken=" + pageToken, function(error,response,body){
-                body = JSON.parse(body);
-                if(!error) {
-                    //youtubeCache.set(cacheKey, body);
-                    callback(null, body);
-                } else {
-                    callback(error);
-                }
+        console.log(requestString + "&pageToken=" + pageToken);
+        request(requestString + "&pageToken=" + pageToken, function (error, response, body) {
+            body = JSON.parse(body);
+            if (!error) {
+                //youtubeCache.set(cacheKey, body);
+                callback(null, body);
+            } else {
+                callback(error);
+            }
 
-            });
+        });
         //}
 
     }


### PR DESCRIPTION
This change removes the Youtube API key from version control.

Instead, a user would have to create a file called `config/local.json` that looks similar to `config/default.json` and enter the Youtube credentials. However, `local.json` is not to be version controlled. It is a local copy.

Before committing, we need to make sure that users can create their own Youtube API key for development and/or use.

If this change is accepted, I would recommend @zach111694 to deactivate the current Youtube API key and create a new one.
